### PR TITLE
heap use-after-free bug fix: AST_ModuleStack

### DIFF
--- a/src/ast/nodes/destroy.c.h
+++ b/src/ast/nodes/destroy.c.h
@@ -244,7 +244,9 @@ void AST_Identifier_free(AST_Identifier_t **ptr)
     if (!ptr) return;
     AST_Identifier_t *identifier = *ptr;
     if (!identifier) return;
+    if (!identifier->identifier_name) return;
     free(identifier->identifier_name);
+    identifier->identifier_name = NULL;
     free(identifier);
     *ptr = NULL;
 }

--- a/src/ast/util/module_stack.c.h
+++ b/src/ast/util/module_stack.c.h
@@ -18,10 +18,10 @@ struct ModuleStack_t *top = NULL;
 /** Push name of current module to module stack */
 void AST_ModuleStack_push(const AST_Identifier_t *module_name)
 {
-    ModuleStack_t *newNode = (ModuleStack_t*) malloc(sizeof(ModuleStack_t));
-    newNode->data = module_name;
-    newNode->next = top;
-    top = newNode;
+    ModuleStack_t *new_node = (ModuleStack_t*) malloc(sizeof(ModuleStack_t));
+    new_node->data = module_name;
+    new_node->next = top;
+    top = new_node;
 }
 
 /** Function to get the top module name from the stack */
@@ -35,13 +35,17 @@ const AST_Identifier_t *AST_ModuleStack_top(void)
 const AST_Identifier_t *AST_ModuleStack_pop(void)
 {
     if (top == NULL) return NULL;
-    const AST_Identifier_t *poppedData = top->data;
     ModuleStack_t *temp = top;
+    const AST_Identifier_t *data = temp->data;
     top = top->next;
-    if (AST_ProcedureMap_empty())
+    if (AST_ProcedureMap_empty()) {
         AST_Identifier_free((AST_Identifier_t**) &temp->data);
+        temp->data = NULL;
+        free(temp);
+        return NULL;
+    }
     free(temp);
-    return poppedData;
+    return data;
 }
 
 /** Empty the stack (doesn't free the (AST_Identifier*)) */

--- a/src/ast/util/module_stack.c.h
+++ b/src/ast/util/module_stack.c.h
@@ -50,7 +50,7 @@ void AST_ModuleStack_clear(void)
     while (top != NULL) {
         ModuleStack_t *temp = top;
         top = top->next;
-        AST_Identifier_free((AST_Identifier_t**) &temp->data);
+        temp->data = NULL;
         free(temp);
     }
 }

--- a/src/lexer/buffer.c.h
+++ b/src/lexer/buffer.c.h
@@ -44,6 +44,7 @@ void lex_buffree()
 {
     if (!lex_buffer) return;
     free(lex_buffer->buffer);
+    lex_buffer->buffer = NULL;
     free(lex_buffer);
     lex_buffer = NULL;
 }


### PR DESCRIPTION
- parser after free heap use fix: ModuleStack_clear doesnt free Identifier_t
- syntax bugfix: added a production of +ve closure over "\n"
- null pointers after free, which are members of structs
